### PR TITLE
Make selenium2library-java 1.6 compliant

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 		<downloadSources>true</downloadSources>
 		<downloadJavadocs>true</downloadJavadocs>
 		<aspectj.version>1.7.3</aspectj.version>
-		<java.version>1.7</java.version>
+		<java.version>1.6</java.version>
 		<xml.doclet.version>1.0.1</xml.doclet.version>
 		<robotframework.version>2.8.1</robotframework.version>
 		<keywords.class>Selenium2Library</keywords.class>

--- a/src/main/java/com/github/markusbernhardt/selenium2library/keywords/SelectElement.java
+++ b/src/main/java/com/github/markusbernhardt/selenium2library/keywords/SelectElement.java
@@ -342,7 +342,7 @@ public class SelectElement extends RunOnFailureKeywordsAdapter {
 		}
 
 		boolean lastItemFound = false;
-		List<String> nonExistingItems = new ArrayList<>();
+		List<String> nonExistingItems = new ArrayList<String>();
 		for (String item : items) {
 			lastItemFound = true;
 			try {


### PR DESCRIPTION
The changes needed to make selenium2library -java 1.6 compliant are just two lines. (New xml-doclet with 1.6 compliant code is also needed.)
