### PR TITLE
Avoid NullPointerException in isEnabled method

### DIFF
--- a/src/main/java/com/github/markusbernhardt/selenium2library/keywords/Element.java
+++ b/src/main/java/com/github/markusbernhardt/selenium2library/keywords/Element.java
@@ -1572,7 +1572,7 @@ public class Element extends RunOnFailureKeywordsAdapter {
 			return false;
 		}
 		String readonly = element.getAttribute("readonly");
-		if (readonly.equals("readonly") || readonly.equals("true")) {
+		if (readonly != null && (readonly.equals("readonly") || readonly.equals("true"))) {
 			return false;
 		}
 


### PR DESCRIPTION
Added null validation of readonly variable in protected boolean  isEnabled(String locator) method. Please see issue https://github.com/MarkusBernhardt/robotframework-selenium2library-java/issues/53

Basically, this avoids a NullPointerException if the html element doesn't have the "readonly" attribute.

Use this Robot test to check it:

```
*** Settings ***
Library  Selenium2Library

*** Test Cases ***

Test Should Be Pass and Should Not Throw a RuntimeException
    Open Browser    http://www.zkoss.org/zkdemo/input/form_sample    firefox    mainbrowser
    Wait Until Keyword Succeeds  10 sec  1 sec  Element Should Be Enabled  //input[../../../td[1]//span[contains(text(), 'Password')]]
    Close All Browsers
```

I am available for any questions you have.

Thank you
