### PR TITLE
Upgrade RobotFramework to 2.8.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 		<aspectj.version>1.7.3</aspectj.version>
 		<java.version>1.6</java.version>
 		<xml.doclet.version>1.0.4</xml.doclet.version>
-		<robotframework.version>2.8.3</robotframework.version>
+		<robotframework.version>2.8.7</robotframework.version>
 		<keywords.class>Selenium2Library</keywords.class>
 	</properties>
 


### PR DESCRIPTION
Upgraded the RobotFramework dependency to the latest stable version before the big jump to 2.9. This upgrade pulls in a bunch of improvements to the stock Robot Framework keyword libraries. 