### PR TITLE
Opening a remote browser with custom web driver timeouts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,12 @@
 			<artifactId>commons-exec</artifactId>
 			<version>1.3</version>
 		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.12</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/github/markusbernhardt/selenium2library/utils/CustomHttpClientFactory.java
+++ b/src/main/java/com/github/markusbernhardt/selenium2library/utils/CustomHttpClientFactory.java
@@ -1,0 +1,61 @@
+package com.github.markusbernhardt.selenium2library.utils;
+
+import org.apache.http.auth.Credentials;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.openqa.selenium.remote.http.HttpClient;
+import org.openqa.selenium.remote.internal.ApacheHttpClient;
+import org.openqa.selenium.remote.internal.HttpClientFactory;
+
+import java.net.URL;
+
+/**
+ * Provides customized {@link HttpClient.Factory} instances.
+ * {@link HttpClient} creation is via delegation to {@link ApacheHttpClient.Factory} as default behavior does.
+ */
+public class CustomHttpClientFactory implements HttpClient.Factory {
+	private final HttpClient.Factory delegate;
+
+	private CustomHttpClientFactory(HttpClientFactory factory) {
+		delegate = new ApacheHttpClient.Factory(factory);
+	}
+
+	@Override
+	public HttpClient createClient(URL url) {
+		return delegate.createClient(url);
+	}
+
+	/**
+	 * Creates a HttpClient.Factory with customized connection and socked timeouts.
+	 * Default timeout values are 2 minutes for connection, and 3 hours for socket as hard-coded in default
+	 * {@link HttpClientFactory} class.
+	 *
+	 * @param connectionTimeout the connection timeout in milliseconds
+	 * @param socketTimeout the socket timeout in milliseconds
+	 * @return a HttpClient.Factory instance that will create
+	 */
+	public static HttpClient.Factory createWithSpecificTimeout(int connectionTimeout, int socketTimeout) {
+		HttpClientFactory factory = new CustomTimeoutHttpClientFactory(connectionTimeout, socketTimeout);
+		return new CustomHttpClientFactory(factory);
+	}
+
+	/**
+	 * {@link HttpClientFactory} is using hard-coded timeouts for connection timeout (2m) and socket timeout (3h).
+	 * This behavior is undesired in some cases, when socket timeout keeps the webdriver blocked for 3 hours on too
+	 * early connection attempt to opened port.
+	 */
+	private static class CustomTimeoutHttpClientFactory extends HttpClientFactory {
+		private final int connectionTimeout;
+		private final int socketTimeout;
+
+		private CustomTimeoutHttpClientFactory(int connectionTimeout, int socketTimeout) {
+			super(connectionTimeout, socketTimeout);
+			this.connectionTimeout = connectionTimeout;
+			this.socketTimeout = socketTimeout;
+		}
+
+		@Override
+		public CloseableHttpClient createHttpClient(Credentials credentials) {
+			return super.createHttpClient(credentials, connectionTimeout, socketTimeout);
+		}
+	}
+}

--- a/src/main/java/com/github/markusbernhardt/selenium2library/utils/TimeUtils.java
+++ b/src/main/java/com/github/markusbernhardt/selenium2library/utils/TimeUtils.java
@@ -1,0 +1,89 @@
+package com.github.markusbernhardt.selenium2library.utils;
+
+/**
+ * Utilities to convert Robot Framework time.
+ */
+public final class TimeUtils {
+	private static final int SECONDS_TO_MILLISECS = 1000;
+	private static final int MINUTES_TO_MILLISECS = 60 * SECONDS_TO_MILLISECS;
+	private static final int HOURS_TO_MILLISECS = 60 * MINUTES_TO_MILLISECS;
+	private static final int DAYS_TO_MILLISECS = 24 * HOURS_TO_MILLISECS;
+
+	private static final String DAYS_PATTERN =  "(\\s*\\d+(\\.\\d+)?\\s*d(ays?)?)?";
+	private static final String HOURS_PATTERN =  "(\\s*\\d+(\\.\\d+)?\\s*h(ours?)?)?";
+	private static final String MINUTES_PATTERN =  "(\\s*\\d+(\\.\\d+)?\\s*m(in((ute)?s?)?)?)?";
+	private static final String SECONDS_PATTERN =  "(\\s*\\d+(\\.\\d+)?\\s*s(ec((ond)?s?))?)?";
+	private static final String MILLISECONDS_PATTERN =  "(\\s*\\d+(\\.\\d+)?\\s*(millis(ec((ond)?s?))?|ms))?";
+	private static final String TIME_STRING_PATTERN = "-?(\\s*\\d+(\\.\\d+)?\\s*|" + DAYS_PATTERN + HOURS_PATTERN +
+			MINUTES_PATTERN + SECONDS_PATTERN + MILLISECONDS_PATTERN + ")";
+
+	private TimeUtils() {
+		// this is a utility class
+	}
+
+	/**
+	 * Converts a Robot Framework time string to milliseconds value.
+	 * See http://robotframework.org/robotframework/latest/libraries/DateTime.html
+	 *
+	 * @param robotTimeString a valid time string
+	 * @return the time in milliseconds
+	 */
+	public static int convertRobotTimeToMillis(String robotTimeString) {
+		int sum = 0;
+		if (!robotTimeString.matches(TIME_STRING_PATTERN)) {
+			throw new IllegalArgumentException("Invalid time string " + robotTimeString);
+		}
+		String[] values = robotTimeString.replaceAll("(\\d)([dhms])", "$1 $2").split("\\s+");
+		try {
+			if (values.length == 1) {
+				return Math.round(Float.parseFloat(values[0]) * SECONDS_TO_MILLISECS);
+			}
+			final int signum = values[0].startsWith("-") ? -1 : 1;
+			if (values.length % 2 != 0) {
+				throw new IllegalArgumentException("Invalid time string " + robotTimeString);
+			}
+			for (int i = 0; i < values.length - 1; i+=2) {
+				final float value = Math.abs(Float.parseFloat(values[i]));
+				final int multiplier = getMultiplier(values[i + 1]);
+				sum += signum * Math.round(value * multiplier);
+			}
+		} catch (NumberFormatException e) {
+			throw new IllegalArgumentException("Invalid time string " + robotTimeString, e);
+		}
+		return sum;
+	}
+
+	private static int getMultiplier(String specifier) {
+		if ("days".equalsIgnoreCase(specifier)
+			|| "day".equalsIgnoreCase(specifier)
+			|| "d".equalsIgnoreCase(specifier)) {
+			return DAYS_TO_MILLISECS;
+		}
+		if ("hours".equalsIgnoreCase(specifier)
+			|| "hour".equalsIgnoreCase(specifier)
+			|| "h".equalsIgnoreCase(specifier)) {
+			return HOURS_TO_MILLISECS;
+		}
+		if ("minutes".equalsIgnoreCase(specifier)
+				|| "minute".equalsIgnoreCase(specifier)
+				|| "mins".equalsIgnoreCase(specifier)
+				|| "min".equalsIgnoreCase(specifier)
+				|| "m".equalsIgnoreCase(specifier)) {
+			return MINUTES_TO_MILLISECS;
+		}
+		if ("seconds".equalsIgnoreCase(specifier)
+				|| "second".equalsIgnoreCase(specifier)
+				|| "secs".equalsIgnoreCase(specifier)
+				|| "sec".equalsIgnoreCase(specifier)
+				|| "s".equalsIgnoreCase(specifier)) {
+			return SECONDS_TO_MILLISECS;
+		}
+		if ("milliseconds".equalsIgnoreCase(specifier)
+				|| "millisecond".equalsIgnoreCase(specifier)
+				|| "millis".equalsIgnoreCase(specifier)
+				|| "ms".equalsIgnoreCase(specifier)) {
+			return 1;
+		}
+		throw new IllegalArgumentException("Invalid time specifier " + specifier);
+	}
+}

--- a/src/test/java/com/github/markusbernhardt/selenium2library/utils/TimeUtilsTest.java
+++ b/src/test/java/com/github/markusbernhardt/selenium2library/utils/TimeUtilsTest.java
@@ -1,0 +1,60 @@
+package com.github.markusbernhardt.selenium2library.utils;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class TimeUtilsTest {
+
+	@Test
+	public void whenNoSpecifier_ShouldConvertSeconds() {
+		assertEquals(1000, TimeUtils.convertRobotTimeToMillis("1"));
+		assertEquals(-2000, TimeUtils.convertRobotTimeToMillis("-2"));
+		assertEquals(500, TimeUtils.convertRobotTimeToMillis("0.5"));
+	}
+
+	@Test
+	public void whenMillisecondsSpecified_ShouldConvertMillisecsonds() {
+		assertEquals(-10, TimeUtils.convertRobotTimeToMillis("-10ms"));
+		assertEquals(1, TimeUtils.convertRobotTimeToMillis("0.8 milliseconds"));
+		assertEquals(1, TimeUtils.convertRobotTimeToMillis("1 millisecond"));
+		assertEquals(1, TimeUtils.convertRobotTimeToMillis("1 millis"));
+	}
+
+	@Test
+	public void whenSecondsSpecified_ShouldConvertSeconds() {
+		assertEquals(-10000, TimeUtils.convertRobotTimeToMillis("-10seconds"));
+		assertEquals(800, TimeUtils.convertRobotTimeToMillis("0.8 s"));
+		assertEquals(1000, TimeUtils.convertRobotTimeToMillis("1 sec"));
+		assertEquals(2000, TimeUtils.convertRobotTimeToMillis("2second"));
+	}
+
+	@Test
+	public void whenMinutesSpecified_ShouldConvertMinutes() {
+		assertEquals(-600000, TimeUtils.convertRobotTimeToMillis("-10min"));
+		assertEquals(48000, TimeUtils.convertRobotTimeToMillis("0.8 m"));
+		assertEquals(60000, TimeUtils.convertRobotTimeToMillis("1 minute"));
+		assertEquals(120000, TimeUtils.convertRobotTimeToMillis("2minutes"));
+	}
+
+	@Test
+	public void whenHoursSpecified_ShouldConvertHours() {
+		assertEquals(-36000000, TimeUtils.convertRobotTimeToMillis("-10h"));
+		assertEquals(3600000, TimeUtils.convertRobotTimeToMillis("1 hour"));
+		assertEquals(5400000, TimeUtils.convertRobotTimeToMillis("1.5 hours"));
+	}
+
+	@Test
+	public void whenDaysSpecified_ShouldConvertDays() {
+		assertEquals(-864000000, TimeUtils.convertRobotTimeToMillis("-10days"));
+		assertEquals(129600000, TimeUtils.convertRobotTimeToMillis("1.5d"));
+		assertEquals(86400000, TimeUtils.convertRobotTimeToMillis("1 day"));
+	}
+
+	@Test
+	public void whenComplexSpecified_ShouldConvertComplex() {
+		assertEquals(151264015, TimeUtils.convertRobotTimeToMillis("1.5d 6 hours 1 minute 4 secs 15ms"));
+		assertEquals(-151264015, TimeUtils.convertRobotTimeToMillis("-1.5d 6 hours 1 minute 4 secs 15ms"));
+	}
+
+}


### PR DESCRIPTION
The default way of creating a web driver has a hard-coded timeout for 3 hours on socket timeout. We are using browser spinned up in docker containers, and no matter if we wait on port to be opened, sometimes it is too early to connect. That ends up in waiting for 3 hours.

This modification adds an overload with two extra arguments for **Open Browser** keyword, and you can specify both connection and socket timeouts. It has effect only for remote browsers of course.

The implementation mimics the original behaviour of default driver creation, and the code plays with internal classes of selenium is isolated.

A **TimeUtils** with JUnit tests also added for convention,so the **Open Browser** keyword understands _Robot Time String format_ and converts them to milliseconds for the API.

Kudos to @JoepWeijers for the patch idea.